### PR TITLE
Install AWS S3 SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /opt/haste
 ADD conf/about.md /opt/haste/
 RUN apk del git && \
     npm install && \
+    npm install aws-sdk && \
     rm -rf /opt/haste/config.js && \
     ln -s /opt/haste/config.json /opt/haste/config.js
 ADD conf/config.json /opt/haste/config.json


### PR DESCRIPTION
I want to use the dockerized version of the haste-server but using an S3 bucket, so I added `npm install aws-sdk` to the Dockerfile to install the AWS SDK.